### PR TITLE
Move README into template format

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,92 @@
+## AM-331-A3 Licencia de Software
+Effective: December 2018
+Contenido de la página
+
+El Software, con excepción de los Documentos de Soporte y Uso, deberá estar sujetos a los siguientes términos y condiciones, los cuales se empaquetarán como parte de cada Software bajo un archivo que llevará el nombre de "LICENCIA" :
+"Copyright © 2018. Banco Interamericano de Desarrollo ("BID"). Uso autorizado."
+
+### 1. Licencia
+Por medio de la presente licencia ("Licencia") no exclusiva, revocable, global y libre de regalías el BID otorga permiso al usuario ("Usuario") para reproducir, distribuir, ejecutar públicamente, prestar y poner a disposición del público, y modificar el software y sus modificaciones, por sí o como parte de una colección, siempre que sea para fines no comerciales, sujeto a los términos y condiciones aquí señalados.
+Salvo indicación en contrario, la Documentación de Soporte y Uso del software se licenciará bajo Creative Commons IGO 3.0 Atribución-NoComercial-SinObraDerivada (CC-IGO 3.0 BY-NC-ND).
+
+#### 2.  Definiciones
+2.1  Software: conjunto de programas, instrucciones y reglas informáticas que permiten ejecutar tareas en una computadora a fin de gestionar un determinado proceso u obtener un determinado resultado. El Software incluye (i) código fuente, (ii) código objeto y (iii) Documentación de Soporte y Uso.
+El Software puede ser del tipo, pero sin estar limitado a (i) programa ejecutable desde el computador, (ii) aplicación móvil y de escritorio, (iii) algoritmo y (iv) hoja de cálculo que contienen macros, así como otras instrucciones para simular, proyectar o realizar otros cálculos.
+2.2  Código Fuente: conjunto de líneas de texto con los pasos que debe seguir la computadora para ejecutar el Software. Puede estar compuesto por un número indeterminado de documentos, con distintas extensiones y organizados en carpetas.
+2.3  Código Objeto: código que resulta de la compilación del Código Fuente. La compilación es un proceso informático que traduce el Código Fuente en lenguaje máquina o bytecode.
+2.4  Documentación de Soporte y Uso (la "Documentación"): se refiere a la información de acompañamiento al código fuente y objeto que permite a un humano comprender los objetivos, arquitectura y lenguaje de programación de Software.
+2.5  Software Derivado: obras derivadas del Software, tales como modificaciones, actualizaciones y mejoras de la misma.
+2.6  Usuario: cualquier persona, natural o jurídica, que obtenga una copia del Software.
+
+### 3.      Derechos del BID
+3.1  El BID se reserva todos los derechos de propiedad intelectual, incluyendo sin limitación derechos de autor, relacionados con o asociados al Software.
+3.2  El BID se reserva expresamente los derechos de ceder, transferir y/o sub-licenciar el Software y/o cualquiera de sus componentes a terceros sin previo aviso.
+
+### 4.      Derechos del Usuario sobre Software Derivado
+El Usuario que desarrolle Software Derivado retendrá todos los derechos de propiedad intelectual, incluyendo sin limitación derechos de autor, relacionados con o asociados al Software Derivado, en el entendido que dicho Software Derivado y cualquier otra edición futura estén sujetas a los mismos términos y condiciones de esta Licencia.
+
+### 5.      Restricciones
+5.1  El Usuario sólo está autorizado a hacer uso del Software conforme se describe en esta Licencia.
+5.2  Con excepción de esta Licencia, el BID no otorga ninguna otra licencia al Usuario con respecto a cualquier otra información u obra propiedad del BID o de cualquier derecho de autor, marcas o cualquier otro derecho de propiedad intelectual del BID. Cualquier licencia adicional deberá ser por escrito y firmada por un representante del BID debidamente autorizado para tales fines.
+5.3  La Licencia no constituye una venta del Software ni de cualquier parte o copia de la misma.
+5.4  El Usuario no podrá usar ni permitir que otros usen el Software para fines comerciales.
+5.5  El Usuario sólo podrá autorizar el uso del Software a terceros de conformidad con lo establecido en esta Licencia, sin que en ningún caso los terceros puedan adquirir más derechos sobre el Software que los expresamente otorgados por el BID mediante esta Licencia.
+
+### 6.      Reconocimiento
+6.1 El Usuario deberá mantener los siguientes enunciados y exenciones en el archivo principal de la Documentación del Software:
+"Copyright © [año]. Banco Interamericano de Desarrollo ("BID"). Uso autorizado.
+Los procedimientos y resultados obtenidos en base a la ejecución de este software son los programados por los desarrolladores y no necesariamente reflejan el punto de vista del BID, de su Directorio Ejecutivo ni de los países que representa."
+6.1.1 En el caso de Software del Fondo Multilateral de Inversiones ("FOMIN"), la exención de responsabilidad deberá ser: "Las opiniones expresadas en esta obra son de los autores y no necesariamente reflejan el punto de vista del BID, de su Directorio Ejecutivo ni de los países que representa, así como tampoco del Comité de Donantes del FOMIN ni de los países que representa."
+6.2 El Usuario podrá incluir en el Software Derivado una referencia al Software como obra original, siempre y cuando dicho aviso no genere confusión alguna respecto a la titularidad de los derechos del BID sobre el Software.
+
+### 7.      Nombre y Logo del BID
+El Usuario no podrá hacer uso del nombre y/o logo del BID para fines diferentes a los aquí estipulados, ni podrá hacer promesas, ni adquirir compromisos u obligaciones, ni otorgar garantías de ninguna clase en nombre del BID.
+
+### 8.      Declaraciones y Garantías
+8.1 El BID otorga esta Licencia sin garantía explícita o implícita de ningún género, objetiva o subjetiva, por responsabilidad contractual o extracontractual, lo que comprende, sin consistir en una enumeración taxativa, garantías de comerciabilidad, adecuación, cumplimiento de normas o requisitos o aplicabilidad para un fin determinado.
+8.2 El BID no garantiza que el funcionamiento del Software será ininterrumpido o libre de errores y no asume obligación alguna de actualizar, corregir ni introducir mejoras en el Software.
+8.3 El Usuario asume exclusivamente el riesgo por su utilización, y así deberá informarlo a terceros cuando utilice, distribuya o ponga el Software a disposición de terceros.
+
+### 9.      Limitación de Responsabilidad
+9.1 El BID no será responsable, bajo circunstancia alguna, de daño ni indemnización, moral o patrimonial; directo o indirecto; accesorio o especial; o por vía de consecuencia, previsto o imprevisto, que pudiese surgir:
+9.1.1  Bajo cualquier teoría de responsabilidad, ya sea por contrato, infracción de derechos de propiedad intelectual, negligencia o bajo cualquier otra teoría; y/o
+9.1.2  A raíz del uso del Software, incluyendo, pero sin limitación de potenciales defectos en el Software, o la pérdida o inexactitud de los datos de cualquier tipo. Lo anterior incluye los gastos o daños asociados a fallas de comunicación y/o fallas de funcionamiento de computadoras, vinculados con la utilización del Software.
+
+### 10.  Indemnización
+10.1 El Usuario se obliga a liberar, defender e indemnizar al BID, su personal y consultores, conforme sea aplicable, de cualquier reclamo, queja, acción, pérdida, demanda, responsabilidad, obligación, daño, costo, incluyendo sin limitación, honorarios de abogados, que pudiesen emprender contra el BID, su personal y/o consultores en virtud de:
+10.1.1  El ejercicio de los derechos otorgados por el BID bajo esta Licencia.
+10.1.2  Incumplimiento de los términos y condiciones de esta Licencia por parte del Usuario.
+10.1.3  Infracción de derechos de autor de terceros por parte del Usuario con relación al uso del Software y el desarrollo de Software Derivado.
+
+### 11.  Terminación de la Licencia
+El BID podrá terminar de manera inmediata esta Licencia, con causa o sin causa, sin dar aviso previo al Usuario. La terminación con causa aplica en caso de que el BID determine, a su entera discreción, que el uso del Software es inconsistente con los términos y condiciones de esta Licencia.
+
+### 12.  Devolución del Sistema Informático
+En caso de terminación de esta Licencia, indistintamente de la causa de terminación y conforme decida el BID, el Usuario deberá inmediatamente cesar el uso del Software y deberá destruir y/o devolver al BID cualesquiera programas, códigos, accesos, archivos o información, impresa y digital, que sean necesarios para que el BID tenga control sobre el Software, sin incluir medida de protección tecnológica alguna. En caso de que el Usuario haya desarrollado Software Derivado y el BID termine la Licencia, el Usuario deberá obtener autorización del BID, por escrito, para poder seguir usando el Software.
+
+### 13.  Ley Aplicable
+Esta Licencia estará sujeta a y será interpretada de conformidad con las leyes del Distrito de Columbia de los Estados Unidos de América, con excepción de sus disposiciones respecto a conflicto de leyes.
+
+### 14.  Privilegios e Inmunidades
+Ninguna cláusula de esta Licencia podrá ser interpretada como un acto de renuncia por parte del BID o de sus funcionarios y empleados a los privilegios e inmunidades que le han sido concedidos como organización internacional pública por su Convenio Constitutivo, por el derecho internacional o por las leyes de cualquiera de sus países miembros.
+
+### 15.  Resolución de Disputas
+Las Partes se comprometen a resolver cualquier diferencia o disputa relacionada con esta Licencia de buena fe y mediante un arreglo amigable. Si al cabo de treinta (30) días calendario de la fecha en que una Parte le comunique a la otra Parte su disconformidad con una diferencia o disputa las Partes no han llegado a un acuerdo satisfactorio para ambas Partes, dicha diferencia o disputa será sometida a arbitraje de conformidad con las reglas de la American Arbitration Association. La determinación final le corresponderá a un único árbitro. El lugar del arbitraje será Washington, Distrito de Columbia, Estados Unidos de América. El idioma que se usará en el proceso de arbitraje será el inglés con traducción simultánea en cualquiera de los idiomas oficiales del BID, si el BID lo solicitara. Los gastos del arbitraje serán cubiertos por ambas Partes en igual proporción.
+
+### 16.  Relación entre las Partes
+Nada de lo contenido en esta Licencia se interpretará como el establecimiento o creación de una asociación ni relación empleador-empleado entre las Partes, las cuales en todo momento permanecerán como contratistas independientes.
+
+### 17.  Divisibilidad
+Si cualquier cláusula de esta Licencia es considerada inválida o inexigible, dicha invalidez o inexigibilidad no afectará a la validez ni la exigibilidad de las demás cláusulas, y dicha cláusula inválida o inexigible se considerará eliminada de esta Licencia.
+
+### 18.  Validez de Obligaciones
+En caso de terminación de esta Licencia sobrevivirán los derechos y las obligaciones previstas en las cláusulas Nos. 3, 7, 8, 9, 10, 13, 14, 15 y 19.
+
+### 19.  Notificaciones
+Cualquier notificación que se requiera en el marco de esta Licencia se hará por escrito al BID a la siguiente cuenta de correo electrónico: code@iadb.org. El BID podrá modificar esta cláusula sin dar previo aviso al Usuario.
+
+### 20.  Enmienda
+Esta Licencia sólo podrá ser modificada mediante autorización previa, expresa y por escrita del BID.
+
+### 21.  Acuerdo Final
+Esta Licencia constituye el acuerdo final entre las Partes y reemplaza todas las comunicaciones, entendimientos o acuerdos, escritos o verbales, de carácter previo entre las Partes con relación al objeto de esta Licencia.

--- a/README-EN.md
+++ b/README-EN.md
@@ -1,7 +1,15 @@
-# IDB OMK Pilot
+Visit the [Publication Guide](el-bid.github.io/guia-de-publicacion/) (currently available in Spanish) for more information about how to publish digital tools.
+To learn more about the Code for Development initiative, visit: www.code.iadb.org
+
+### IDB OMK Pilot
+### Description and Context
+---
+
 OpenMapKit pilot implementation for IDB
 
-## Server 
+### User Guide
+
+#### Server
 An OMK server has been setup using a HOT OSM Fork:
 * https://github.com/hotosm/OpenMapKitServer/
 
@@ -17,7 +25,7 @@ The page show surveys that were created
 And registered administrators can view submissions
 ![screenshot from 2018-12-17 17 09 52](https://user-images.githubusercontent.com/1014341/50119005-6ef06200-021f-11e9-96e1-16ae6b9334f6.png)
 
-## Client App
+#### Client App
 Two Android apps must be installed
 * OpenMapKit: https://play.google.com/store/apps/details?id=org.redcross.openmapkit&hl=en_US
 * OpenDataKit Collect: https://play.google.com/store/apps/details?id=org.odk.collect.android
@@ -33,6 +41,37 @@ Finally, the forms are submitted to the server and the administrator can review 
 
 This dashboard allows downloading in both GeoJSON and CSV formats.
 
-## Documentation
+#### Documentation
 * OMK https://docs.opendatakit.org/
 * XLSForm (Survey Format) http://xlsform.org/en/
+
+### Installation Guide
+---
+
+#### Dependencies
+
+### How to Contribute
+---
+
+### Code of Conduct
+---
+
+### Authors
+---
+
+### Additional Information
+---
+
+### License
+---
+
+[AM-331-A3 Licencia de Software](LICENSE.md)
+
+### Limitation of responsibilities
+---
+
+The IDB is not responsible, under any circumstance, for damage or compensation, moral or patrimonial; direct or indirect; accessory or special; or by way of consequence, foreseen or unforeseen, that could arise:
+
+I. Under any concept of intellectual property, negligence or detriment of another part theory; I
+
+ii. Following the use of the Digital Tool, including, but not limited to defects in the Digital Tool, or the loss or inaccuracy of data of any kind. The foregoing includes expenses or damages associated with communication failures and / or malfunctions of computers, linked to the use of the Digital Tool.


### PR DESCRIPTION
Takes the existing README contents and moves them into the template
format. Placeholder sections are added as well.

Also adds the same license used in the extraction tool to this repo.